### PR TITLE
Embrace guzzlehttp/psr7 for URI and Streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ To enable the use of future-proof PSR-15 middlewares via partial PSR-7 adapers.
 ```php
 // not fully PSR-7 compliant lazy adapters
 $serverRequestAdapter = \brnc\Symfony1\Message\Adapter\Request::fromSfWebRequest($sfWebRequest);
-$responseAdapter      = new \brnc\Symfony1\Message\Adapter\Response($sfWebResponse);
+$responseAdapter      = \brnc\Symfony1\Message\Adapter\Response::fromSfWebReponse($sfWebResponse);
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ To enable the use of future-proof PSR-15 middlewares via partial PSR-7 adapers.
 ## Usage example
 ```php
 // not fully PSR-7 compliant lazy adapters
-$serverRequestAdapter = new \brnc\Symfony1\Message\Adapter\Request($sfWebRequest);
+$serverRequestAdapter = \brnc\Symfony1\Message\Adapter\Request::fromSfWebRequest($sfWebRequest);
 $responseAdapter      = new \brnc\Symfony1\Message\Adapter\Response($sfWebResponse);
 ```

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "files": ["mock/sfWebRequest.php", "mock/sfWebResponse.php"]
     },
     "scripts": {
-        "phpunit": "phpunit --coverage-text",
+        "phpunit": "phpunit --coverage-html coverage --coverage-text",
         "test": [
             "@phpunit"
         ]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     },
     "require": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "guzzlehttp/psr7": "^1.6"
     },
     "archive": {
         "exclude": ["vendor/*", "tests/", "mock/", ".*", "phpunit.xml.dist", "coverage/"]

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,170 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92d1677532185ba5840cdb12c7338ce8",
-    "packages": [],
+    "content-hash": "445b99e18003e36a2d99f363571d1863",
+    "packages": [
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2019-03-08T08:55:37+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/mock/sfWebRequest.php
+++ b/mock/sfWebRequest.php
@@ -1,4 +1,6 @@
-<?php /** @noinspection PhpUnusedParameterInspection */
+<?php
+/** @noinspection PhpUnusedParameterInspection */
+/** @noinspection ReturnTypeCanBeDeclaredInspection */
 
 /**
  * Minimal mock of symfony's sfWebRequest to enable standalone testing
@@ -111,7 +113,7 @@ class sfWebRequest
     {
         $key = strtoupper(str_replace('-', '_', ($prefix ? $prefix . '_' : '') . $name));
 
-        return isset($this->pathInfoArray[$key]) ? $this->pathInfoArray[$key] : null;
+        return $this->pathInfoArray[$key] ?? null;
     }
 
     /**
@@ -122,7 +124,7 @@ class sfWebRequest
      */
     public function getCookie($name, $defaultValue = null)
     {
-        return isset($this->cookie[$name]) ? $this->cookie[$name] : $defaultValue;
+        return $this->cookie[$name] ?? $defaultValue;
     }
 
     /**

--- a/mock/sfWebRequest.php
+++ b/mock/sfWebRequest.php
@@ -26,6 +26,9 @@ class sfWebRequest
     /** @var string[] */
     private $cookie;
 
+    /** @var string|null */
+    private $content;
+
     /**
      * dummy constructor to preserve the original signature → please initialise with prepare() afterwards!
      *
@@ -40,12 +43,13 @@ class sfWebRequest
     }
 
     /**
-     * @param string $method
-     * @param array  $server
-     * @param array  $get
-     * @param array  $post
-     * @param array  $cookie
-     * @param array  $requestParameters
+     * @param string      $method
+     * @param array       $server
+     * @param array       $get
+     * @param array       $post
+     * @param array       $cookie
+     * @param array       $requestParameters
+     * @param string|null $content
      */
     public function prepare(
         $method,
@@ -53,7 +57,8 @@ class sfWebRequest
         array $get = [],
         array $post = [],
         array $cookie = [],
-        array $requestParameters = []
+        array $requestParameters = [],
+        ?string $content = null
     ) {
         $this->method            = $method;
         $this->pathInfoArray     = $server;
@@ -61,6 +66,7 @@ class sfWebRequest
         $this->postParameters    = $post;
         $this->cookie            = $cookie;
         $this->requestParameters = $requestParameters;
+        $this->content           = $content;
     }
 
     /**
@@ -150,6 +156,6 @@ class sfWebRequest
      */
     public function getContent()
     {
-        return false;
+        return $this->content ?? false;
     }
 }

--- a/mock/sfWebRequest.php
+++ b/mock/sfWebRequest.php
@@ -29,6 +29,9 @@ class sfWebRequest
     /** @var string|null */
     private $content;
 
+    /** @var string|null */
+    private $uri;
+
     /**
      * dummy constructor to preserve the original signature → please initialise with prepare() afterwards!
      *
@@ -50,6 +53,7 @@ class sfWebRequest
      * @param array       $cookie
      * @param array       $requestParameters
      * @param string|null $content
+     * @param string|null $uri
      */
     public function prepare(
         $method,
@@ -58,7 +62,8 @@ class sfWebRequest
         array $post = [],
         array $cookie = [],
         array $requestParameters = [],
-        ?string $content = null
+        ?string $content = null,
+        ?string $uri = null
     ) {
         $this->method            = $method;
         $this->pathInfoArray     = $server;
@@ -67,6 +72,7 @@ class sfWebRequest
         $this->cookie            = $cookie;
         $this->requestParameters = $requestParameters;
         $this->content           = $content;
+        $this->uri               = $uri;
     }
 
     /**
@@ -157,5 +163,13 @@ class sfWebRequest
     public function getContent()
     {
         return $this->content ?? false;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUri(): ?string
+    {
+        return $this->uri ?? 'http://localhost:80/';
     }
 }

--- a/mock/sfWebRequest.php
+++ b/mock/sfWebRequest.php
@@ -144,4 +144,12 @@ class sfWebRequest
     {
         return $this->requestParameters;
     }
+
+    /**
+     * @return string|false
+     */
+    public function getContent()
+    {
+        return false;
+    }
 }

--- a/mock/sfWebRequest.php
+++ b/mock/sfWebRequest.php
@@ -1,5 +1,7 @@
 <?php
+
 /** @noinspection PhpUnusedParameterInspection */
+
 /** @noinspection ReturnTypeCanBeDeclaredInspection */
 
 /**

--- a/mock/sfWebResponse.php
+++ b/mock/sfWebResponse.php
@@ -20,6 +20,9 @@ class sfWebResponse
     /** @var array */
     private $cookies;
 
+    /** @var bool */
+    private $headerOnly = false;
+
     /**
      * @param mixed $dispatcher
      * @param array $options
@@ -92,8 +95,8 @@ class sfWebResponse
     }
 
     /**
-     * @param  string $name
-     * @param  string $default
+     * @param string $name
+     * @param string $default
      *
      * @return string
      */
@@ -174,12 +177,28 @@ class sfWebResponse
     }
 
     /**
-     * @param  string $name Header name
+     * @param string $name Header name
      *
      * @return string Normalized header
      */
     protected function normalizeHeaderName($name)
     {
         return ucwords(str_replace(['_', ' '], '-', strtolower($name)), '-');
+    }
+
+    /**
+     * @param bool $value
+     */
+    public function setHeaderOnly($value = true)
+    {
+        $this->headerOnly = (bool)$value;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHeaderOnly()
+    {
+        return $this->headerOnly;
     }
 }

--- a/mock/sfWebResponse.php
+++ b/mock/sfWebResponse.php
@@ -37,12 +37,14 @@ class sfWebResponse
      * @param string|null $reasonPhrase
      * @param string[]    $headers
      * @param array       $cookies
+     * @param bool        $headerOnly
      */
-    public function prepare($code = 200, $reasonPhrase = null, $headers = [], $cookies = [])
+    public function prepare($code = 200, $reasonPhrase = null, $headers = [], $cookies = [], $headerOnly = false)
     {
         $this->setStatusCode($code, $reasonPhrase);
-        $this->headers = $headers;
-        $this->cookies = $cookies;
+        $this->headers    = $headers;
+        $this->cookies    = $cookies;
+        $this->headerOnly = $headerOnly;
     }
 
     /** @return int */

--- a/mock/sfWebResponse.php
+++ b/mock/sfWebResponse.php
@@ -1,5 +1,7 @@
 <?php
+
 /** @noinspection PhpUnusedParameterInspection */
+
 /** @noinspection ReturnTypeCanBeDeclaredInspection */
 
 /**

--- a/mock/sfWebResponse.php
+++ b/mock/sfWebResponse.php
@@ -1,4 +1,6 @@
-<?php /** @noinspection PhpUnusedParameterInspection */
+<?php
+/** @noinspection PhpUnusedParameterInspection */
+/** @noinspection ReturnTypeCanBeDeclaredInspection */
 
 /**
  * Minimal mock of symfony's sfWebResponse to enable standalone testing
@@ -106,7 +108,7 @@ class sfWebResponse
     {
         $normalizedName = $this->normalizeHeaderName($name);
 
-        return isset($this->headers[$normalizedName]) ? $this->headers[$normalizedName] : $default;
+        return $this->headers[$normalizedName] ?? $default;
     }
 
     /**

--- a/src/Adapter/CommonAdapterTrait.php
+++ b/src/Adapter/CommonAdapterTrait.php
@@ -1,5 +1,6 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
 
 namespace brnc\Symfony1\Message\Adapter;
 

--- a/src/Adapter/CommonAdapterTrait.php
+++ b/src/Adapter/CommonAdapterTrait.php
@@ -1,6 +1,10 @@
 <?php
+declare(strict_types = 1);
 
 namespace brnc\Symfony1\Message\Adapter;
+
+use function GuzzleHttp\Psr7\stream_for;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * collects common behaviour of request and response
@@ -13,6 +17,9 @@ trait CommonAdapterTrait
      * shadow to honour: »[…]preserve the exact case in which headers were originally specified.«
      */
     protected $headerNames = [];
+
+    /** @var StreamInterface|null */
+    protected $body;
 
     /**
      * @param string          $name
@@ -55,6 +62,14 @@ trait CommonAdapterTrait
         $this->setHeader($name, $value);
 
         return $this;
+    }
+
+    /**
+     * @return StreamInterface
+     */
+    public function getBody(): StreamInterface
+    {
+        return $this->body ? $this->body : stream_for('');
     }
 
     /**

--- a/src/Adapter/CommonAdapterTrait.php
+++ b/src/Adapter/CommonAdapterTrait.php
@@ -69,7 +69,7 @@ trait CommonAdapterTrait
      */
     public function getBody(): StreamInterface
     {
-        return $this->body ? $this->body : stream_for('');
+        return $this->body ?: stream_for();
     }
 
     /**
@@ -96,7 +96,7 @@ trait CommonAdapterTrait
     protected function explodeHeaderLine(string $line): array
     {
         return array_map(
-            function ($v) {
+            static function ($v) {
                 return trim($v, " \t"); // https://tools.ietf.org/html/rfc7230#section-3.2.4
             },
             explode(',', $line)

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
 declare(strict_types = 1);
 
 namespace brnc\Symfony1\Message\Adapter;
@@ -296,14 +297,10 @@ class Request
 
     /**
      * @param StreamInterface $body
-     *
-     * @return $this
      */
     public function withBody(StreamInterface $body)
     {
         throw new \LogicException('Altering content is not supported by sfRequest.');
-
-        return $this;
     }
 
     /**

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -16,7 +16,6 @@ use ReflectionObject;
  *      Cookie handling
  *          Cookie Abstraction
  *              including Header transcription
- *      Request Target and URI handling (using guzzle PSR-7?)
  *      Proper Interface?
  */
 class Request
@@ -308,6 +307,30 @@ class Request
         throw new \LogicException('Altering content is not supported by sfRequest.');
 
         return $this;
+    }
+
+    /**
+     * @return UriInterface
+     */
+    public function getUri(): UriInterface
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestTarget(): string
+    {
+        $target = $this->uri->getPath();
+        if ('' === $target) {
+            $target = '/';
+        }
+        if ('' !== $this->uri->getQuery()) {
+            $target .= '?' . $this->uri->getQuery();
+        }
+
+        return $target;
     }
 
     /**

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -6,7 +6,9 @@ namespace brnc\Symfony1\Message\Adapter;
 use GuzzleHttp\Psr7\CachingStream;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 use ReflectionObject;
 
 /**
@@ -37,6 +39,9 @@ class Request
 
     /** @var mixed[] */
     protected $attributes = [];
+
+    /** @var UriInterface */
+    protected $uri;
 
     /**
      * @var string
@@ -73,6 +78,8 @@ class Request
         if (isset($options[self::OPTION_EXPOSE_SF_WEB_REQUEST])) {
             $instance->attributes[self::ATTRIBUTE_SF_WEB_REQUEST] = $sfWebRequest;
         }
+
+        $instance->uri = new Uri($sfWebRequest->getUri());
 
         return $instance;
     }

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -46,14 +46,8 @@ class Request
      */
     protected $method;
 
-    /**
-     * @param \sfWebRequest $sfWebRequest
-     */
-    public function __construct(\sfWebRequest $sfWebRequest)
+    private function __construct()
     {
-        $this->sfWebRequest = $sfWebRequest;
-        // inititialise path array
-        $sfWebRequest->getPathInfoArray();
     }
 
     /**
@@ -64,7 +58,8 @@ class Request
      */
     public static function fromSfWebRequest(\sfWebRequest $sfWebRequest, array $options = []): self
     {
-        $instance = new static($sfWebRequest);
+        $instance               = new static();
+        $instance->sfWebRequest = $sfWebRequest;
 
         if (isset($options[self::OPTION_BODY_USE_STREAM])) {
             // CachingStream is writable unless target is specified, actuall sfWebRequest doesn't allow content manipulation

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -43,10 +43,7 @@ class Request
     protected $uri;
 
     /**
-     * @var string
-     *
-     * shadow to honour: »[…]method names are case-sensitive and thus implementations SHOULD NOT modify the given
-     * string.«
+     * @var string shadow to honour: »[…]method names are case-sensitive and thus implementations SHOULD NOT modify the given string.«
      */
     protected $method;
 
@@ -124,7 +121,7 @@ class Request
 
             if (null !== $useKey) {
                 $headerName = $this->normalizeHeaderName($useKey);
-
+                /** @noinspection NullCoalescingOperatorCanBeUsedInspection */
                 if (isset($this->headerNames[$headerName])) {
                     $headerName = $this->headerNames[$headerName]; // return shadowed header name
                 }

--- a/src/Adapter/Request.php
+++ b/src/Adapter/Request.php
@@ -1,6 +1,7 @@
 <?php
+
 /** @noinspection PhpFullyQualifiedNameUsageInspection */
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace brnc\Symfony1\Message\Adapter;
 

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -38,12 +38,8 @@ class Response
     /** @var bool if setHeaderOnly()-automagic is used on withStatus() calls */
     protected $setHeaderOnly = true;
 
-    /**
-     * @param \sfWebResponse $sfWebResponse
-     */
-    public function __construct(\sfWebResponse $sfWebResponse)
+    private function __construct()
     {
-        $this->sfWebResponse = $sfWebResponse;
     }
 
     /**
@@ -54,13 +50,14 @@ class Response
      */
     public static function fromSfWebReponse(\sfWebResponse $sfWebResponse, array $options = []): self
     {
-        $instance = new static($sfWebResponse);
+        $new = new static();
+        $new->sfWebResponse = $sfWebResponse;
 
         if (isset($options[self::OPTION_SEND_BODY_ON_204])) {
-            $instance->setHeaderOnly = false;
+            $new->setHeaderOnly = false;
         }
 
-        return $instance;
+        return $new;
     }
 
     /**

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -1,6 +1,7 @@
 <?php
+
 /** @noinspection PhpFullyQualifiedNameUsageInspection */
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace brnc\Symfony1\Message\Adapter;
 
@@ -54,7 +55,7 @@ class Response
      */
     public static function fromSfWebReponse(\sfWebResponse $sfWebResponse, array $options = []): self
     {
-        $new = new static();
+        $new                = new static();
         $new->sfWebResponse = $sfWebResponse;
 
         if (isset($options[self::OPTION_SEND_BODY_ON_204])) {
@@ -266,6 +267,7 @@ class Response
         if (!empty($reasonPhrase)) {
             return $reasonPhrase;
         }
+
         // either return internal default for null to trigger symfony's default lookup
         return static::$defaultReasonPhrases[$code] ?? null;
     }

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -12,7 +12,10 @@ use ReflectionObject;
  *          Access raw Response?
  *          Cookie Abstraction
  *              including Header transcription
+ *          how to sync to sfResponse? What happends if header and setRawCookie of sfResponse collide?
  *      withBody and how to sync writes to the stream with the underlying sfWebResponse
+ *         via Refl.eventDispatcher && response.filter_content ?
+ *         vs. clone Stream on withBody and write to sfResponse
  *      Proper Interface?
  *      Wrapper for Setters using sfEvent ~Dispatcher ?
  */

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -167,7 +167,7 @@ class Response
      */
     public function withStatus($code, $reasonPhrase = ''): self
     {
-        if ($this->setHeaderOnly) { // TODO: cover with tests!
+        if ($this->setHeaderOnly) {
             $setNoContent = self::STATUS_NO_CONTENT === $code;
             // only change if there's a transition from or to 204
             if ($setNoContent xor self::STATUS_NO_CONTENT === (int)$this->sfWebResponse->getStatusCode()) {
@@ -197,7 +197,6 @@ class Response
      *
      * @param array $options
      *
-     * @throws \ReflectionException
      * @throws \ReflectionException
      */
     protected function retroduceOptions(array $options): void

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -12,6 +12,7 @@ use ReflectionObject;
  *          Access raw Response?
  *          Cookie Abstraction
  *              including Header transcription
+ *      withBody and how to sync writes to the stream with the underlying sfWebResponse
  *      Proper Interface?
  *      Wrapper for Setters using sfEvent ~Dispatcher ?
  */

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -1,4 +1,5 @@
 <?php
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
 declare(strict_types = 1);
 
 namespace brnc\Symfony1\Message\Adapter;
@@ -264,7 +265,6 @@ class Response
         if (!empty($reasonPhrase)) {
             return $reasonPhrase;
         }
-
         // either return internal default for null to trigger symfony's default lookup
         return static::$defaultReasonPhrases[$code] ?? null;
     }

--- a/src/Adapter/Response.php
+++ b/src/Adapter/Response.php
@@ -12,7 +12,6 @@ use ReflectionObject;
  *          Cookie Abstraction
  *              including Header transcription
  *      Proper Interface?
- *      cover $setHeaderOnly with tests!
  *      Wrapper for Setters using sfEvent ~Dispatcher ?
  */
 class Response

--- a/tests/Adapter/RequestBasicTest.php
+++ b/tests/Adapter/RequestBasicTest.php
@@ -36,7 +36,7 @@ class RequestBasicTest extends TestCase
     public function testMethod()
     {
         $mock    = $this->createSymfonyMock();
-        $request = new Request($mock);
+        $request = Request::fromSfWebRequest($mock);
         $this->assertSame(null, $request->getMethod());
         $request = $request->withMethod('PuRgE');
         $this->assertSame('PuRgE', $request->getMethod());
@@ -185,7 +185,7 @@ class RequestBasicTest extends TestCase
         array $requestParameters = [],
         array $options = []
     ) {
-        return new Request($this->createSymfonyMock($method, $server, $get, $post, $cookie, $requestParameters, $options));
+        return Request::fromSfWebRequest($this->createSymfonyMock($method, $server, $get, $post, $cookie, $requestParameters, $options));
     }
 
     /**

--- a/tests/Adapter/RequestReadingTest.php
+++ b/tests/Adapter/RequestReadingTest.php
@@ -26,7 +26,7 @@ class RequestReadingTest extends TestCase
     {
         $sfWebRequest = new \sfWebRequest();
         $sfWebRequest->prepare($request['method'], $request['server']);
-        $readingRequestMock = new Request($sfWebRequest);
+        $readingRequestMock = Request::fromSfWebRequest($sfWebRequest);
 
         $this->assertSame($hasHeader, $readingRequestMock->hasHeader($headerName));
     }
@@ -46,7 +46,7 @@ class RequestReadingTest extends TestCase
     {
         $sfWebRequest = new \sfWebRequest();
         $sfWebRequest->prepare($request['method'], $request['server']);
-        $readingRequestMock = new Request($sfWebRequest);
+        $readingRequestMock = Request::fromSfWebRequest($sfWebRequest);
         $this->assertSame($getHeader, $readingRequestMock->getHeader($headerName));
     }
 
@@ -71,7 +71,7 @@ class RequestReadingTest extends TestCase
     ) {
         $sfWebRequest = new \sfWebRequest();
         $sfWebRequest->prepare($request['method'], $request['server']);
-        $readingRequestMock = new Request($sfWebRequest);
+        $readingRequestMock = Request::fromSfWebRequest($sfWebRequest);
         $this->assertSame($getHeaderLine, $readingRequestMock->getHeaderLine($headerName));
     }
 
@@ -96,7 +96,7 @@ class RequestReadingTest extends TestCase
     ) {
         $sfWebRequest = new \sfWebRequest();
         $sfWebRequest->prepare($request['method'], $request['server']);
-        $readingRequestMock = new Request($sfWebRequest);
+        $readingRequestMock = Request::fromSfWebRequest($sfWebRequest);
         $this->assertSame($expectedHeaders, $readingRequestMock->getHeaders($headerName));
     }
 
@@ -204,7 +204,7 @@ class RequestReadingTest extends TestCase
     {
         $sfWebRequest = new \sfWebRequest();
         $sfWebRequest->prepare($request['method'], $request['server']);
-        $readingRequestMock = new Request($sfWebRequest);
+        $readingRequestMock = Request::fromSfWebRequest($sfWebRequest);
         $this->assertSame($expectedVersion, $readingRequestMock->getProtocolVersion());
     }
 

--- a/tests/Adapter/ResponseBasicTest.php
+++ b/tests/Adapter/ResponseBasicTest.php
@@ -56,13 +56,13 @@ class ResponseBasicTest extends TestCase
         $this->assertSame(204, $symfony->getStatusCode());
         $this->assertSame('No reason phrase given', $symfony->getStatusText());
 
-        $response = $response->withStatus('200');
+        $response = $response->withStatus(200);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('OK', $response->getReasonPhrase());
         $this->assertSame(200, $symfony->getStatusCode());
         $this->assertSame('OK', $symfony->getStatusText());
 
-        $response = $response->withStatus('400', '*** Bad Request ***');
+        $response = $response->withStatus(400, '*** Bad Request ***');
         $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('*** Bad Request ***', $response->getReasonPhrase());
         $this->assertSame(400, $symfony->getStatusCode());
@@ -79,7 +79,7 @@ class ResponseBasicTest extends TestCase
          * @var \sfWebResponse $symfony
          */
         list($response, $symfony) = $this->createResponse(204);
-        $response = $response->withStatus('308');
+        $response = $response->withStatus(308);
         $this->assertSame(308, $response->getStatusCode());
         $this->assertSame('Permanent Redirect', $response->getReasonPhrase());
         $this->assertSame(308, $symfony->getStatusCode());

--- a/tests/Adapter/ServerRequestBasicTest.php
+++ b/tests/Adapter/ServerRequestBasicTest.php
@@ -101,25 +101,25 @@ class ServerRequestBasicTest extends TestCase
     }
 
     /**
-     * @param null  $method
-     * @param array $server
-     * @param array $get
-     * @param array $post
-     * @param array $cookie
-     * @param array $requestParameters
-     * @param array $options
+     * @param string|null $method
+     * @param array       $server
+     * @param array       $get
+     * @param array       $post
+     * @param array       $cookie
+     * @param array       $requestParameters
+     * @param array       $options
      *
      * @return Request
      */
     private function createRequest(
-        $method = null,
+        ?string $method = null,
         array $server = [],
         array $get = [],
         array $post = [],
         array $cookie = [],
         array $requestParameters = [],
         array $options = []
-    ) {
+    ): Request {
         $symfonyRequestMock = new \sfWebRequest(null, [], [], $options);
         $symfonyRequestMock->prepare($method, $server, $get, $post, $cookie, $requestParameters);
 

--- a/tests/Adapter/ServerRequestBasicTest.php
+++ b/tests/Adapter/ServerRequestBasicTest.php
@@ -185,6 +185,6 @@ class ServerRequestBasicTest extends TestCase
         $symfonyRequestMock = new \sfWebRequest(null, [], [], $options);
         $symfonyRequestMock->prepare($method, $server, $get, $post, $cookie, $requestParameters);
 
-        return new Request($symfonyRequestMock);
+        return Request::fromSfWebRequest($symfonyRequestMock);
     }
 }

--- a/tests/Adapter/ServerRequestBasicTest.php
+++ b/tests/Adapter/ServerRequestBasicTest.php
@@ -18,7 +18,7 @@ class ServerRequestBasicTest extends TestCase
     {
         $symfonyRequestMock = new \sfWebRequest();
         $symfonyRequestMock->prepare('GET');
-        $request = new Request($symfonyRequestMock, true);
+        $request = Request::fromSfWebRequest($symfonyRequestMock, [Request::OPTION_EXPOSE_SF_WEB_REQUEST => true]);
         $this->assertSame($symfonyRequestMock, $request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST));
         $this->assertSame(spl_object_hash($symfonyRequestMock), spl_object_hash($request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST)));
     }

--- a/tests/Adapter/ServerRequestBasicTest.php
+++ b/tests/Adapter/ServerRequestBasicTest.php
@@ -3,17 +3,13 @@
 namespace brnc\Tests\Symfony1\Message\Adapter;
 
 use brnc\Symfony1\Message\Adapter\Request;
-use GuzzleHttp\Psr7\Stream;
-use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\StreamInterface;
 
 /**
  * tests methods beyond the scope of PSR-7's Message Interface
  */
 class ServerRequestBasicTest extends TestCase
 {
-
     /**
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
@@ -24,64 +20,6 @@ class ServerRequestBasicTest extends TestCase
         $request = Request::fromSfWebRequest($symfonyRequestMock, [Request::OPTION_EXPOSE_SF_WEB_REQUEST => true]);
         $this->assertSame($symfonyRequestMock, $request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST));
         $this->assertSame(spl_object_hash($symfonyRequestMock), spl_object_hash($request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST)));
-    }
-
-    public function testBareConstructorGetBody()
-    {
-        $request = $this->createRequest();
-        $body    = $request->getBody();
-        $this->assertInstanceOf(StreamInterface::class, $body);
-        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
-        $this->assertSame(true, $body->isReadable(), 'Default getBody() should be readable.');
-        $this->assertSame(true, $body->isWritable(), 'Default getBody() should be writable.');
-    }
-
-    public function testStaticConstructionGetBody()
-    {
-        $symfonyRequestMock = new \sfWebRequest();
-        $symfonyRequestMock->prepare('GET');
-        $request = Request::fromSfWebRequest($symfonyRequestMock);
-        $body    = $request->getBody();
-        $this->assertInstanceOf(StreamInterface::class, $body);
-        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
-        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
-        $this->assertSame(true, $body->isWritable(), 'Static constructed getBody() is writable as a quirk.');
-    }
-
-    public function testStaticConstructionGetBodyHasContent()
-    {
-        $symfonyRequestMock = new \sfWebRequest();
-        $symfonyRequestMock->prepare('GET', [], [], [], [], [], 'dummy content');
-        $request = Request::fromSfWebRequest($symfonyRequestMock);
-        $body    = $request->getBody();
-        $this->assertInstanceOf(Stream::class, $body);
-        $this->assertSame('dummy content', $body->getContents(), 'Expected stream to have content.');
-        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
-        $this->assertSame(true, $body->isWritable(), 'Static constructed getBody() is writable as a quirk.');
-    }
-
-    public function testStaticConstructionUsingPhpInputGetBody()
-    {
-        $symfonyRequestMock = new \sfWebRequest();
-        $symfonyRequestMock->prepare('GET');
-        $request = Request::fromSfWebRequest(
-            $symfonyRequestMock,
-            [Request::OPTION_BODY_USE_STREAM => true]
-        );
-        $body    = $request->getBody();
-        $this->assertInstanceOf(StreamInterface::class, $body);
-        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
-        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
-        $this->assertSame(true, $body->isWritable(), 'Static constructed  getBody() is writable as a quirk.');
-    }
-
-    /**
-     * @expectedException \LogicException
-     */
-    public function testItFailsWithBody()
-    {
-        $request    = $this->createRequest();
-        $newRequest = $request->withBody(stream_for(''));
     }
 
     /**

--- a/tests/Adapter/ServerRequestBasicTest.php
+++ b/tests/Adapter/ServerRequestBasicTest.php
@@ -3,7 +3,10 @@
 namespace brnc\Tests\Symfony1\Message\Adapter;
 
 use brnc\Symfony1\Message\Adapter\Request;
+use GuzzleHttp\Psr7\Stream;
+use function GuzzleHttp\Psr7\stream_for;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * tests methods beyond the scope of PSR-7's Message Interface
@@ -14,13 +17,71 @@ class ServerRequestBasicTest extends TestCase
     /**
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
-    public function testConstrucWithAttribute()
+    public function testStaticConstructionWithAttribute()
     {
         $symfonyRequestMock = new \sfWebRequest();
         $symfonyRequestMock->prepare('GET');
         $request = Request::fromSfWebRequest($symfonyRequestMock, [Request::OPTION_EXPOSE_SF_WEB_REQUEST => true]);
         $this->assertSame($symfonyRequestMock, $request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST));
         $this->assertSame(spl_object_hash($symfonyRequestMock), spl_object_hash($request->getAttribute(Request::ATTRIBUTE_SF_WEB_REQUEST)));
+    }
+
+    public function testBareConstructorGetBody()
+    {
+        $request = $this->createRequest();
+        $body    = $request->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
+        $this->assertSame(true, $body->isReadable(), 'Default getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Default getBody() should be writable.');
+    }
+
+    public function testStaticConstructionGetBody()
+    {
+        $symfonyRequestMock = new \sfWebRequest();
+        $symfonyRequestMock->prepare('GET');
+        $request = Request::fromSfWebRequest($symfonyRequestMock);
+        $body    = $request->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
+        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Static constructed getBody() is writable as a quirk.');
+    }
+
+    public function testStaticConstructionGetBodyHasContent()
+    {
+        $symfonyRequestMock = new \sfWebRequest();
+        $symfonyRequestMock->prepare('GET', [], [], [], [], [], 'dummy content');
+        $request = Request::fromSfWebRequest($symfonyRequestMock);
+        $body    = $request->getBody();
+        $this->assertInstanceOf(Stream::class, $body);
+        $this->assertSame('dummy content', $body->getContents(), 'Expected stream to have content.');
+        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Static constructed getBody() is writable as a quirk.');
+    }
+
+    public function testStaticConstructionUsingPhpInputGetBody()
+    {
+        $symfonyRequestMock = new \sfWebRequest();
+        $symfonyRequestMock->prepare('GET');
+        $request = Request::fromSfWebRequest(
+            $symfonyRequestMock,
+            [Request::OPTION_BODY_USE_STREAM => true]
+        );
+        $body    = $request->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
+        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Static constructed  getBody() is writable as a quirk.');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testItFailsWithBody()
+    {
+        $request    = $this->createRequest();
+        $newRequest = $request->withBody(stream_for(''));
     }
 
     /**

--- a/tests/Adapter/ServerRequestBodyTest.php
+++ b/tests/Adapter/ServerRequestBodyTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace brnc\Tests\Symfony1\Message\Adapter;
+
+use brnc\Symfony1\Message\Adapter\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+
+class ServerRequestBodyTest extends TestCase
+{
+    public function testConstructorGetBody()
+    {
+        $body = $this->createRequest('POST')->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
+        $this->assertSame(true, $body->isReadable(), 'Default getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Default getBody() is writable as a quirk.');
+    }
+
+    public function testStaticConstructionGetBodyHasContent()
+    {
+        $body = $this->createRequest('POST', [], 'dummy content')->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('dummy content', $body->getContents(), 'Expected stream to have content.');
+        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Static constructed getBody() is writable as a quirk.');
+    }
+
+    public function testStaticConstructionUsingPhpInputGetBody()
+    {
+        $body = $this->createRequest('POST', [Request::OPTION_BODY_USE_STREAM => true])->getBody();
+        $this->assertInstanceOf(StreamInterface::class, $body);
+        $this->assertSame('', $body->getContents(), 'Expected empty stream.');
+        $this->assertSame(true, $body->isReadable(), 'Static constructed getBody() should be readable.');
+        $this->assertSame(true, $body->isWritable(), 'Static constructed  getBody() is writable as a quirk.');
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testItFailsWithBody()
+    {
+        $request    = $this->createRequest();
+        $newRequest = $request->withBody($this->createMock(StreamInterface::class));
+    }
+
+    /**
+     * @param null        $method
+     * @param array       $adapterOptions
+     * @param string|null $content
+     * @param string|null $uri
+     *
+     * @return Request
+     */
+    private function createRequest(
+        $method = null,
+        array $adapterOptions = [],
+        ?string $content = null,
+        ?string $uri = null
+    ): Request {
+        $symfonyRequestMock = new \sfWebRequest();
+        $symfonyRequestMock->prepare($method, [], [], [], [], [], $content, $uri);
+
+        return Request::fromSfWebRequest($symfonyRequestMock, $adapterOptions);
+    }
+}

--- a/tests/Adapter/ServerRequestBodyTest.php
+++ b/tests/Adapter/ServerRequestBodyTest.php
@@ -45,7 +45,7 @@ class ServerRequestBodyTest extends TestCase
     }
 
     /**
-     * @param null        $method
+     * @param string|null $method
      * @param array       $adapterOptions
      * @param string|null $content
      * @param string|null $uri
@@ -53,7 +53,7 @@ class ServerRequestBodyTest extends TestCase
      * @return Request
      */
     private function createRequest(
-        $method = null,
+        ?string $method = null,
         array $adapterOptions = [],
         ?string $content = null,
         ?string $uri = null

--- a/tests/Adapter/ServerRequestUriTargetUrlTest.php
+++ b/tests/Adapter/ServerRequestUriTargetUrlTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace brnc\Tests\Symfony1\Message\Adapter;
+
+use brnc\Symfony1\Message\Adapter\Request;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
+
+class ServerRequestUriTargetUrlTest extends TestCase
+{
+    public function testGetUriDefault()
+    {
+        $uri = $this->createRequest(null)->getUri();
+        $this->assertInstanceOf(UriInterface::class, $uri);
+        $this->assertSame('http://localhost/', $uri->__toString());
+    }
+
+    public function testGetUri()
+    {
+        $uri = $this->createRequest('https://example.com:1337/foo/bar?q=bar&a=42#fragment')->getUri();
+        $this->assertInstanceOf(UriInterface::class, $uri);
+        $this->assertSame('https://example.com:1337/foo/bar?q=bar&a=42#fragment', $uri->__toString());
+    }
+
+    public function testGetRequestTargetDefaultMock()
+    {
+        $requestTarget = $this->createRequest(null)->getRequestTarget();
+        $this->assertSame('/', $requestTarget);
+    }
+
+    public function testGetRequestTargetDefaultEmpty()
+    {
+        $request = $this->createRequest('');
+        $this->assertSame('/', $request->getRequestTarget());;
+    }
+
+    public function testGetRequestTarget()
+    {
+        $requestTarget = $this->createRequest('https://example.com:1337/foo/bar?q=baz&a=42#fragment')->getRequestTarget();
+        $this->assertSame('/foo/bar?q=baz&a=42', $requestTarget);
+    }
+
+    /**
+     * TODO cover and activate!
+     *
+     * @expectedException \LogicException
+     */
+    public function ItFailsWithUri()
+    {
+        $request    = $this->createRequest();
+        $newRequest = $request->withUri($this->createMock(UriInterface::class));
+    }
+
+    /**
+     *
+     * @param string|null $uri
+     * @param string|null $method
+     *
+     * @return Request
+     */
+    private function createRequest(
+        ?string $uri = null,
+        ?string $method = 'GET'
+    ): Request {
+        $symfonyRequestMock = new \sfWebRequest();
+        $symfonyRequestMock->prepare($method, [], [], [], [], [], null, $uri);
+
+        return Request::fromSfWebRequest($symfonyRequestMock);
+    }
+}

--- a/tests/ResponseMockTest.php
+++ b/tests/ResponseMockTest.php
@@ -104,6 +104,6 @@ class ResponseMockTest extends TestCase
         $symfonyResponseMock = new \sfWebResponse(null, $options);
         $symfonyResponseMock->prepare($code, $reasonPhrase, $headers, $cookies);
 
-        return [new Response($symfonyResponseMock), $symfonyResponseMock];
+        return [Response::fromSfWebReponse($symfonyResponseMock), $symfonyResponseMock];
     }
 }


### PR DESCRIPTION
Use guzzlehttp/psr7 to deal with Body, Uri, and RequestTarget in Request.
Minor code tweaks.