### PR TITLE
Add support for GuzzleHttp\Psr7 ^2 (Release 1.3.2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "php": "^7.4 || ^8.0",
         "webmozart/assert": "^1.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr-4": {
             "brnc\\Tests\\Symfony1\\Message\\": "tests/"
         },
-        "files": ["mock/sfWebRequest.php", "mock/sfWebResponse.php", "mock/sfEventDispatcher.php", "mock/sfEvent.php"]
+        "files": ["mock/sfWebRequest.php", "mock/sfWebResponse.php", "mock/sfEventDispatcher.php", "mock/sfEvent.php", "mock/guzzle-psr7/function_include.php"]
     },
     "scripts": {
         "phpunit": "phpunit --coverage-html coverage --coverage-text --colors=auto",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15ed741bebcc099d046ef6859975ff8f",
+    "content-hash": "384673cf1f17e78f7df5497a4002ce4b",
     "packages": [
         {
             "name": "guzzlehttp/psr7",

--- a/mock/guzzle-psr7/function_include.php
+++ b/mock/guzzle-psr7/function_include.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * TODO remove this and the whole directory once php-http/psr7-integration-tests
+ *      supports GuzzleHttp\Psr7 ^2
+ *
+ * Sadly needed as php-http/psr7-integration-tests @ 1.1.1
+ * relies on the deprecated GuzzleHttp\Psr7::stream_for instead of Utils::streamFor
+ */
+if (!function_exists('GuzzleHttp\Psr7\stream_for')) {
+    require __DIR__ . '/stream_for.php';
+}

--- a/mock/guzzle-psr7/stream_for.php
+++ b/mock/guzzle-psr7/stream_for.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+/*
+ * TODO remove this and the whole directory once php-http/psr7-integration-tests
+ *      supports GuzzleHttp\Psr7 ^2
+ *
+ * Sadly needed as php-http/psr7-integration-tests @ 1.1.1
+ * relies on the deprecated GuzzleHttp\Psr7::stream_for instead of Utils::streamFor
+ */
+function stream_for($resource = '', array $options = [])
+{
+    return \GuzzleHttp\Psr7\Utils::streamFor($resource, $options);
+}


### PR DESCRIPTION
Sadly needed as php-http/psr7-integration-tests @ 1.1.1 relies on
  the deprecated GuzzleHttp\Psr7::stream_for instead of Utils::streamFor

TODO remove this including the whole directory
  once php-http/psr7-integration-tests supports GuzzleHttp\Psr7 ^2