### PR TITLE
Add CookieHeaderTranscriptor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "guzzlehttp/psr7": "^2.4.5",
+        "psr/clock": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",
         "webmozart/assert": "^1.11"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f9fc788cf319782df2fe86f2241ee12",
+    "content-hash": "158f197b9eec1a48ae23a0d11e212fe5",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -121,6 +121,54 @@
                 }
             ],
             "time": "2023-12-03T20:05:35+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/mock/sfWebResponse.php
+++ b/mock/sfWebResponse.php
@@ -163,13 +163,13 @@ class sfWebResponse
     }
 
     /**
-     * @param string $name
-     * @param string $value
-     * @param null   $expire
-     * @param string $path
-     * @param string $domain
-     * @param bool   $secure
-     * @param bool   $httpOnly
+     * @param string          $name
+     * @param string          $value
+     * @param null|int|string $expire
+     * @param string          $path
+     * @param string          $domain
+     * @param bool            $secure
+     * @param bool            $httpOnly
      */
     public function setCookie(
         $name,
@@ -235,9 +235,9 @@ class sfWebResponse
     }
 
     /**
+     * @return null|string
      * @deprecated Only for testing! Original methods echos instead of returning
      *
-     * @return null|string
      */
     public function sendContent()
     {

--- a/src/Factory/NowFactory.php
+++ b/src/Factory/NowFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace brnc\Symfony1\Message\Factory;
+
+use Psr\Clock\ClockInterface;
+
+class NowFactory implements ClockInterface
+{
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+}

--- a/src/Transcriptor/Response/CookieHeaderTranscriptor.php
+++ b/src/Transcriptor/Response/CookieHeaderTranscriptor.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace brnc\Symfony1\Message\Transcriptor\Response;
+
+use brnc\Symfony1\Message\Factory\NowFactory;
+use Psr\Clock\ClockInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Applies `Set-Cookie` headers from PSR7 to  `sfWebResponse` via `setCookie`
+ *
+ * SameSite attribute is lost, as `sfWebResponse` doesn't support it.
+ */
+class CookieHeaderTranscriptor implements CookieTranscriptorInterface
+{
+    /** @var array<string, null|bool|string> */
+    private const ATTRIBUTES = [
+        'expires'  => '',
+        'max-age'  => '',
+        'path'     => '/',
+        'domain'   => '',
+        'secure'   => false,
+        'httponly' => false,
+        'samesite' => 'Lax', // Default to Lax if not specified
+        'ttl'      => null,
+    ];
+    private ClockInterface $nowFactory;
+
+    public function __construct(?ClockInterface $nowFactory = null)
+    {
+        $this->nowFactory = $nowFactory ?? new NowFactory();
+    }
+
+    public function transcribeCookies(ResponseInterface $psrResponse, \sfWebResponse $sfWebResponse): void
+    {
+        $cookies = $psrResponse->getHeader('Set-Cookie');
+
+        foreach ($cookies as $cookie) {
+            $parts          = explode(';', $cookie);
+            $cookieData     = array_shift($parts);
+            [$name, $value] = [...explode('=', $cookieData, 2), ''];
+            /** @var array{expires: string, max-age: string, path: string, domain: string, secure: bool, httponly: bool, samesite:string, ttl: null|int} $attributes */
+            $attributes = self::ATTRIBUTES;
+
+            foreach ($parts as $part) {
+                $part                   = trim($part);
+                [$attrName, $attrValue] = [...explode('=', $part, 2), ''];
+                $attrName               = strtolower($attrName);
+                if (array_key_exists($attrName, self::ATTRIBUTES)) {
+                    if ('secure' === $attrName || 'httponly' === $attrName) {
+                        $attributes[$attrName] = ('' === $attrValue);
+                    } else {
+                        $attributes[$attrName] = $attrValue;
+                    }
+                }
+            }
+
+            // Calculate expiration from Max-Age if present
+            if ('' !== $attributes['max-age']) {
+                $maxAgeTime = $this->nowFactory->now()->getTimestamp() + (int)$attributes['max-age'];
+                if ('' === $attributes['expires'] || $maxAgeTime < strtotime($attributes['expires'])) {
+                    $attributes['ttl'] = $maxAgeTime;
+                }
+            }
+
+            if ('' !== $attributes['expires'] && !is_numeric($attributes['ttl'])) {
+                $epoch             = strtotime($attributes['expires']);
+                $attributes['ttl'] = false === $epoch ? null : $epoch;
+            }
+
+            // Apply the cookie using your internal function
+            $sfWebResponse->setCookie(
+                $name,
+                $value,
+                $attributes['ttl'],
+                $attributes['path'],
+                $attributes['domain'],
+                $attributes['secure'],
+                $attributes['httponly']
+            );
+        }
+    }
+}

--- a/tests/Transcriptor/Response/CookieHeaderTranscriptorTest.php
+++ b/tests/Transcriptor/Response/CookieHeaderTranscriptorTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace brnc\Tests\Symfony1\Message\Transcriptor\Response;
+
+use brnc\Symfony1\Message\Transcriptor\Response\CookieHeaderTranscriptor;
+use brnc\Symfony1\Message\Transcriptor\ResponseTranscriptor;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+/**
+ * @internal
+ *
+ * @covers \brnc\Symfony1\Message\Transcriptor\Response\CookieHeaderTranscriptor
+ */
+final class CookieHeaderTranscriptorTest extends TestCase
+{
+    /**
+     * @param array<int,string>                                                                                                              $fixture
+     * @param array<string,array{name: string, value: string, expire: null|int, path: string, domain: string, secure: bool, httpOnly: bool}> $expectation
+     *
+     * @dataProvider provideCookieCases
+     * @dataProvider provideMultiCookieCases
+     */
+    public function testTranscribeFailCookies(array $fixture, array $expectation): void
+    {
+        $psr7Response = new Response(203);
+        foreach ($fixture as $cookie) {
+            $psr7Response = $psr7Response->withAddedHeader('Set-Cookie', $cookie);
+        }
+
+        $mockResponse = $symfonyResponseMock = new \sfWebResponse(null, ['http_protocol' => 'HTTP/1.0', 'charset' => 'utf-8', 'content_type' => 'text/html', 'send_http_headers' => true]);
+        $symfonyResponseMock->prepare(205, null, ['X-Preset-Header' => 'sfWebResponse'], []);
+        $symfonyResponseMock->setCookie('sfWebResponseDefault', 'preset');
+
+        $clockMock = new class() implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('1970-01-01T00:01:03', new \DateTimeZone('UTC'));
+            }
+        };
+
+        $transcription = (new ResponseTranscriptor(null, new CookieHeaderTranscriptor($clockMock)))->transcribe($psr7Response, $mockResponse);
+
+        $expectation = array_merge(
+            ['sfWebResponseDefault' => ['name' => 'sfWebResponseDefault', 'value' => 'preset', 'expire' => null, 'path' => '/', 'domain' => '', 'secure' => false, 'httpOnly' => false]],
+            $expectation,
+        );
+
+        self::assertSame($expectation, $transcription->getCookies());
+        self::assertNull($transcription->getHttpHeader('Set-Cookie'));
+    }
+
+    /** @return array<string, array{set-cookie: string[], expectation: array<string,array{name: string, value: string, expire: null|int, path: string, domain: string, secure: bool, httpOnly: bool}>}> */
+    public static function provideMultiCookieCases(): iterable
+    {
+        return [
+            'Correctly handly multiple cookies' => [
+                'set-cookie'  => [
+                    'token=42; Domain=cookie.test; Path=/; HttpOnly',
+                    'sessionId=abc123; Path=/; HttpOnly; SameSite=Strict',
+                    'token=1337; Domain=cookie.test; Path=/; Expires=Sun, 12 Dec 2025 13:37:42 GMT; SameSite=Lax; Secure; HttpOnly',
+                ],
+                'expectation' => [
+                    'token'     => [
+                        'name'     => 'token',
+                        'value'    => '1337',
+                        'expire'   => 1765719462,  // Epoch timestamp for 'Sun, 12 Dec 2025 13:37:42 GMT'
+                        'path'     => '/',
+                        'domain'   => 'cookie.test',
+                        'secure'   => true,
+                        'httpOnly' => true,
+                    ],
+                    'sessionId' => [
+                        'name'     => 'sessionId',
+                        'value'    => 'abc123',
+                        'expire'   => null,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => true,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @return array<string, array{set-cookie: string[], expectation: array<string,array{name: string, value: string, expire: null|int, path: string, domain: string, secure: bool, httpOnly: bool}>}> */
+    public static function provideCookieCases(): iterable
+    {
+        return [
+            'Basic Cookie'                  => [
+                'set-cookie'  => ['sessionId=abc123; Path=/; HttpOnly; SameSite=Strict'],
+                'expectation' => [
+                    'sessionId' => [
+                        'name'     => 'sessionId',
+                        'value'    => 'abc123',
+                        'expire'   => null,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => true,
+                    ],
+                ],
+            ],
+            'Broken Cookie value'           => [
+                'set-cookie'  => ['sessionId'],
+                'expectation' => [
+                    'sessionId' => [
+                        'name'     => 'sessionId',
+                        'value'    => '',
+                        'expire'   => null,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => false,
+                    ],
+                ],
+            ],
+            'Unknown Attribute'             => [
+                'set-cookie'  => ['sessionId=abc123; Unknown'],
+                'expectation' => [
+                    'sessionId' => [
+                        'name'     => 'sessionId',
+                        'value'    => 'abc123',
+                        'expire'   => null,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => false,
+                    ],
+                ],
+            ],
+            'Cookie with All Attributes'    => [
+                'set-cookie'  => ['token=1337; Domain=cookie.test; Path=/; Expires=Sun, 12 Dec 2025 13:37:42 GMT; SameSite=Lax; Secure; HttpOnly'],
+                'expectation' => [
+                    'token' => [
+                        'name'     => 'token',
+                        'value'    => '1337',
+                        'expire'   => 1765719462,  // Epoch timestamp for 'Sun, 12 Dec 2025 13:37:42 GMT'
+                        'path'     => '/',
+                        'domain'   => 'cookie.test',
+                        'secure'   => true,
+                        'httpOnly' => true,
+                    ],
+                ],
+            ],
+            'Cookie with Max-Age'           => [
+                'set-cookie'  => ['userSettings=darkMode; Max-Age=3600; HttpOnly'],
+                'expectation' => [
+                    'userSettings' => [
+                        'name'     => 'userSettings',
+                        'value'    => 'darkMode',
+                        'expire'   => 3663,  // 3600 seconds plus mocked epoch 63
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => true,
+                    ],
+                ],
+            ],
+            'Cookie with Max-Age < Expires' => [
+                'set-cookie'  => ['maxage=LTexpires; Expires=Thu, 01 Jan 1970 01:00:10 GMT; Max-Age=' . (3600 - 63)],
+                'expectation' => [
+                    'maxage' => [
+                        'name'     => 'maxage',
+                        'value'    => 'LTexpires',
+                        'expire'   => 3600,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => false,
+                    ],
+                ],
+            ],
+            'Cookie with Max-Age > Expires' => [
+                'set-cookie'  => ['maxage=GTexpires; Expires=Thu, 01 Jan 1970 01:00:00 GMT; Max-Age=3610'],
+                'expectation' => [
+                    'maxage' => [
+                        'name'     => 'maxage',
+                        'value'    => 'GTexpires',
+                        'expire'   => 3600,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => false,
+                    ],
+                ],
+            ],
+            'Secure Only Cookie'            => [
+                'set-cookie'  => ['admin=true; Secure; HttpOnly'],
+                'expectation' => [
+                    'admin' => [
+                        'name'     => 'admin',
+                        'value'    => 'true',
+                        'expire'   => null,
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => true,
+                        'httpOnly' => true,
+                    ],
+                ],
+            ],
+            'Cookie With Invalid Expires'   => [
+                'set-cookie'  => ['debug=false; Expires=Invalid-Date; Path=/'],
+                'expectation' => [
+                    'debug' => [
+                        'name'     => 'debug',
+                        'value'    => 'false',
+                        'expire'   => null, // Null due to invalid date format
+                        'path'     => '/',
+                        'domain'   => '',
+                        'secure'   => false,
+                        'httpOnly' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Applies `Set-Cookie` headers from PSR7 to  `sfWebResponse` via `setCookie` SameSite attribute is lost, as `sfWebResponse` doesn't support it.